### PR TITLE
FIX yealink 2015-03: zip files instead of rar files

### DIFF
--- a/plugins/xivo-yealink/2015-03/pkgs/pkgs.db
+++ b/plugins/xivo-yealink/2015-03/pkgs/pkgs.db
@@ -10,7 +10,7 @@ description: Firmware for Yealink T20P
 description_fr: Micrologiciel pour Yealink T20P
 version: 9.73.0.50
 files: T20P-fw
-install: yealink-fw-rar
+install: yealink-fw
 
 [pkg_T21P-fw]
 description: Firmware for Yealink T21P
@@ -24,14 +24,14 @@ description: Firmware for Yealink T22P
 description_fr: Micrologiciel pour Yealink T22P
 version: 7.73.0.50
 files: T22P-fw
-install: yealink-fw-rar
+install: yealink-fw
 
 [pkg_T26P-fw]
 description: Firmware for Yealink T26P
 description_fr: Micrologiciel pour Yealink T26P
 version: 6.73.0.50
 files: T26P-fw
-install: yealink-fw-rar
+install: yealink-fw
 
 [pkg_T28P-fw]
 description: Firmware for Yealink T28P


### PR DESCRIPTION
Following my previous PR, I found an issue when trying to install the new version of the plugin on my home Xivo server for Yealink T26P:

```
2015-04-26 22:04:00,803 [769] (INFO) (provd.plugins): Installing plugin-package T26P-fw
2015-04-26 22:04:00,804 [769] (INFO) (twisted): 127.0.0.1 - - [26/Apr/2015:20:04:00 +0000] "POST /provd/pg_mgr/plugins/xivo-yealink-2015-03/install/install HTTP/1.1" 201 - "-" "-"
2015-04-26 22:04:00,816 [769] (ERROR) (xivo_fetchfw.install): Error during execution of installation manager
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/xivo_fetchfw/install.py", line 80, in execute
    filter_obj.apply(input_dir, output_dir)
  File "/usr/lib/python2.7/dist-packages/xivo_fetchfw/install.py", line 419, in apply
    retcode = subprocess.call(cmd)
  File "/usr/lib/python2.7/subprocess.py", line 493, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1259, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

I changed the rar vs zip stuff, and it fixed the issue.