### PR TITLE
Display line number as label for T41 and T42

### DIFF
--- a/plugins/xivo-yealink/2015-03/templates/T41P.tpl
+++ b/plugins/xivo-yealink/2015-03/templates/T41P.tpl
@@ -1,9 +1,5 @@
 {% extends 'base.tpl' -%}
 
-{% block sip_line_label %}
-account.{{ line['XX_line_no'] }}.label = {{ line['display_name'] }} {{ line['number'] }}
-{% endblock %}
-
 {% block sip_servers %}
 account.{{ line['XX_line_no'] }}.sip_server.1.address = {{ line['proxy_ip'] }}
 account.{{ line['XX_line_no'] }}.sip_server.1.port = {{ line['proxy_port'] }}

--- a/plugins/xivo-yealink/2015-03/templates/T42G.tpl
+++ b/plugins/xivo-yealink/2015-03/templates/T42G.tpl
@@ -1,9 +1,5 @@
 {% extends 'base.tpl' -%}
 
-{% block sip_line_label %}
-account.{{ line['XX_line_no'] }}.label = {{ line['display_name'] }} {{ line['number'] }}
-{% endblock %}
-
 {% block sip_servers %}
 account.{{ line['XX_line_no'] }}.sip_server.1.address = {{ line['proxy_ip'] }}
 account.{{ line['XX_line_no'] }}.sip_server.1.port = {{ line['proxy_port'] }}

--- a/plugins/xivo-yealink/2015-03/templates/base.tpl
+++ b/plugins/xivo-yealink/2015-03/templates/base.tpl
@@ -58,9 +58,7 @@ security.user_password = {{ admin_username|d('admin') }}:{{ admin_password|d('ad
 {% for line in sip_lines.itervalues() %}
 
 account.{{ line['XX_line_no'] }}.enable = 1
-{% block sip_line_label scoped %}
 account.{{ line['XX_line_no'] }}.label = {{ line['number']|d(line['display_name']) }}
-{% endblock %}
 account.{{ line['XX_line_no'] }}.display_name = {{ line['display_name'] }}
 account.{{ line['XX_line_no'] }}.auth_name = {{ line['auth_username'] }}
 account.{{ line['XX_line_no'] }}.user_name = {{ line['username'] }}


### PR DESCRIPTION
T41 and T42 were configured with
  Firstname Lastname
as the account Label.
This label is displayed in line key label.

Since this label displays only 6 characters it is worthless to display 'Firstname Lastname'.
We then chose to display only the line number - like for the other model by the way.

This reverts commit 85f0e0f657dd5689b4e748d684474c36c1986a05