### PR TITLE
Remove dns_server1 bloc

### DIFF
--- a/plugins/xivo-snom/common/templates/base.tpl
+++ b/plugins/xivo-snom/common/templates/base.tpl
@@ -23,10 +23,6 @@
     <http_pass perm="R">guest</http_pass>
     {% endif -%}
 
-    {% if dns_enabled -%}
-    <dns_server1 perm="R">{{ dns_ip }}</dns_server1>
-    {% endif -%}
-
     {% if ntp_enabled -%}
     <ntp_server perm="R">{{ ntp_ip }}</ntp_server>
     {% else -%}


### PR DESCRIPTION
issue #5819 : dns_server1 option is not configurable and useless if we provide it through dhcp