### PR TITLE
Few bugfixes for Cisco SPA514G (may affect others SPA)

### DIFF
--- a/dhcp/dhcp/dhcpd_update/ciscosmb.conf
+++ b/dhcp/dhcp/dhcpd_update/ciscosmb.conf
@@ -99,3 +99,11 @@ subclass "voip-mac-address-prefix" 1:00:e1:6d {
         log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Cisco PREFIX 1:00:e1:6d"));
     }
 }
+
+subclass "voip-mac-address-prefix" 1:a4:93:4c {
+    if not exists vendor-class-identifier {
+        option tftp-server-name = concat(config-option VOIP.http-server-uri, "/spa$PSN.cfg");
+        log(concat("[", binary-to-ascii(16, 8, ":", hardware), "] ", "BOOT Cisco PREFIX 1:a4:93:4c"));
+    }
+}
+

--- a/plugins/xivo-cisco-spa/common/common.py
+++ b/plugins/xivo-cisco-spa/common/common.py
@@ -286,6 +286,7 @@ class BaseCiscoPlugin(StandardPlugin):
             return
         nb_keys, nb_expmods = self._NB_FKEY[model]
         lines = []
+        range_nbkeys = range(2,nb_keys+1)
         for funckey_no, funckey_dict in sorted(raw_config[u'funckeys'].iteritems(),
                                                key=itemgetter(0)):
             funckey_type = funckey_dict[u'type']
@@ -306,6 +307,7 @@ class BaseCiscoPlugin(StandardPlugin):
                              (funckey_no, label, funckey_no))
                 lines.append(u'<Extended_Function_%s_>%s</Extended_Function_%s_>' %
                              (funckey_no, function, funckey_no))
+                range_nbkeys.remove(funckey_no)
             else:
                 expmod_keynum = keynum - nb_keys - 1
                 expmod_no = expmod_keynum // 32 + 1
@@ -316,6 +318,7 @@ class BaseCiscoPlugin(StandardPlugin):
                     lines.append(u'<Unit_%s_Key_%s>%s</Unit_%s_Key_%s>' %
                                  (expmod_no, expmod_key_no, function, expmod_no, expmod_key_no))
         raw_config[u'XX_fkeys'] = u'\n'.join(lines)
+        raw_config[u'XX_range_nbkeys'] = range_nbkeys
 
     def _format_dst_change(self, dst_change):
         _day = dst_change['day']

--- a/plugins/xivo-cisco-spa/common/templates/base.tpl
+++ b/plugins/xivo-cisco-spa/common/templates/base.tpl
@@ -38,8 +38,8 @@
 {% endblock -%}
 
 <Voice_Mail_Number>{{ exten_voicemail }}</Voice_Mail_Number>
-<Call_Pickup_Code>{{ exten_pickup_call }}</Call_Pickup_Code>
-<Attendant_Console_Call_Pickup_Code>{{ exten_pickup_call }}</Attendant_Console_Call_Pickup_Code>
+<Call_Pickup_Code>{{ exten_pickup_call }}#</Call_Pickup_Code>
+<Attendant_Console_Call_Pickup_Code>{{ exten_pickup_call }}#</Attendant_Console_Call_Pickup_Code>
 
 {% if '1' in sip_lines -%}
 <Station_Name>{{ sip_lines['1']['display_name']|e }}</Station_Name>

--- a/plugins/xivo-cisco-spa/common/templates/base.tpl
+++ b/plugins/xivo-cisco-spa/common/templates/base.tpl
@@ -86,16 +86,12 @@
 {% endfor %}
 
 {% if '1' in sip_lines -%}
-<Extension_2_>1</Extension_2_>
-<Short_Name_2_>{{ sip_lines['1']['number']|d('$USER') }}</Short_Name_2_>
-<Extended_Function_2_></Extended_Function_2_>
-<Extension_3_>1</Extension_3_>
-<Short_Name_3_>{{ sip_lines['1']['number']|d('$USER') }}</Short_Name_3_>
-<Extended_Function_3_></Extended_Function_3_>
-<Extension_4_>1</Extension_4_>
-<Short_Name_4_>{{ sip_lines['1']['number']|d('$USER') }}</Short_Name_4_>
-<Extended_Function_4_></Extended_Function_4_>
-{% endif -%}
+{% for line_no in XX_range_nbkeys -%}
+<Extension_{{ line_no }}_>1</Extension_{{ line_no }}_>
+<Short_Name_{{ line_no }}_>{{ sip_lines['1']['number']|d('$USER') }}</Short_Name_{{ line_no }}_>
+<Extended_Function_{{ line_no }}_></Extended_Function_{{ line_no }}_>
+{% endfor -%}
+{% endif %}
 
 {% if XX_xivo_phonebook_url -%}
 <XML_Directory_Service_Name>{{ XX_directory_name }}</XML_Directory_Service_Name>

--- a/plugins/xivo-cisco-spa/common/templates/base.tpl
+++ b/plugins/xivo-cisco-spa/common/templates/base.tpl
@@ -85,6 +85,18 @@
 <Extended_Function_{{ line_no }}_></Extended_Function_{{ line_no }}_>
 {% endfor %}
 
+{% if '1' in sip_lines -%}
+<Extension_2_>1</Extension_2_>
+<Short_Name_2_>{{ sip_lines['1']['number']|d('$USER') }}</Short_Name_2_>
+<Extended_Function_2_></Extended_Function_2_>
+<Extension_3_>1</Extension_3_>
+<Short_Name_3_>{{ sip_lines['1']['number']|d('$USER') }}</Short_Name_3_>
+<Extended_Function_3_></Extended_Function_3_>
+<Extension_4_>1</Extension_4_>
+<Short_Name_4_>{{ sip_lines['1']['number']|d('$USER') }}</Short_Name_4_>
+<Extended_Function_4_></Extended_Function_4_>
+{% endif -%}
+
 {% if XX_xivo_phonebook_url -%}
 <XML_Directory_Service_Name>{{ XX_directory_name }}</XML_Directory_Service_Name>
 <XML_Directory_Service_URL>{{ XX_xivo_phonebook_url|e }}</XML_Directory_Service_URL>


### PR DESCRIPTION
Two bugfixes for SPA phones (seen on SPA514G, may affect others SPA):
- Call pickup with fn keys not working
- New DHCP prefix

One enhancement for SPA phones:
- Bind internal fn keys for multi-call managing (if the phone have only one SIP line)

All tested on a clean Xivo 15.18 using a brand new SPA514G with SPA500S expansion module.