### PR TITLE
Display display_name instead of the line number

### DIFF
--- a/plugins/xivo-yealink/v80/templates/base.tpl
+++ b/plugins/xivo-yealink/v80/templates/base.tpl
@@ -84,7 +84,7 @@ security.user_password = {{ admin_username|d('admin') }}:{{ admin_password|d('ad
 {% for line_no, line in XX_sip_lines.iteritems() -%}
 {% if line -%}
 account.{{ line_no }}.enable = 1
-account.{{ line_no }}.label = {{ line['number']|d(line['display_name']) }}
+account.{{ line_no }}.label = {{ line['display_name']|d(line['number']) }}
 account.{{ line_no }}.display_name = {{ line['display_name'] }}
 account.{{ line_no }}.auth_name = {{ line['auth_username'] }}
 account.{{ line_no }}.user_name = {{ line['username'] }}


### PR DESCRIPTION
We just tried some Yealink T48G phones and, by default, they always display the phone number instead of the user name.
Here is a proposition to commit for displaying the name instead of phone number by default, if configured.