### PR TITLE
small regex modif

### DIFF
--- a/plugins/xivo-yealink/common/common.py
+++ b/plugins/xivo-yealink/common/common.py
@@ -36,9 +36,9 @@ logger = logging.getLogger('plugin.xivo-yealink')
 
 class BaseYealinkHTTPDeviceInfoExtractor(object):
     _UA_REGEX_LIST = [
-        re.compile(r'^[yY]ealink\s+SIP(?: VP)?-(\w+)\s+([\d.]+)\s+([\da-f:]{17})$'),
-        re.compile(r'^[yY]ealink\s+(CP860)\s+([\d.]+)\s+([\da-f:]{17})$'),
-        re.compile(r'(VP530P?|W52P)\s+([\d.]+)\s+([\da-f:]{17})$'),
+        re.compile(r'^[yY]ealink\s+SIP(?: VP)?-(\w+)\s+([\d.]+)\s+([\da-fA-F:]{17})$'),
+        re.compile(r'^[yY]ealink\s+(CP860)\s+([\d.]+)\s+([\da-fA-F:]{17})$'),
+        re.compile(r'(VP530P?|W52P)\s+([\d.]+)\s+([\da-fA-F:]{17})$'),
         re.compile(r'[yY]ealink-(\w+)\s+([\d.]+)\s+([\d.]+)$'),
     ]
 


### PR DESCRIPTION
It seems that the UA of Yealink sometimes use capitals in the mac address.
This causes provd to not find the correct plugin since the regex only matches on lowercase characters.

Example UA: "Yealink SIP-T41P 36.80.0.95 00:15:65:61:B0:FC"

The patch fixes this.